### PR TITLE
add iproute installation to allow use of ansible_default_ipv4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yum makecache fast \
       sudo \
       which \
       wget \
+      iproute \
  && yum clean all
 
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers


### PR DESCRIPTION
and v6 as well since those are tested with ip get by ansible facts gathering